### PR TITLE
Fix PFT extractor docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,12 @@ jupyter notebook pft_xml_extraction/pft_xml.ipynb
 
 The notebook will save CSV and JSON outputs alongside the input files unless you provide alternative paths.
 
-The `pft_xml_extraction` folder contains `pft_extraction.py` which converts PFT
-XML files into JSON and CSV tables.
+The `pft_xml_extraction` folder contains `pft_extractor.py` which converts PFT
+XML files into JSON and CSV tables. From inside that directory run:
 
 ```bash
-python pft_xml_extraction/pft_extraction.py
+python pft_extractor.py input/*.xml --output output
 ```
 
-Place your XML files in `pft_xml_extraction/input` and the outputs will be
-written next to them under `pft_xml_extraction/output`.
-main
+Place your XML files in `input` and the outputs will be
+written next to them under `output`.

--- a/pft_xml_extraction/README.md
+++ b/pft_xml_extraction/README.md
@@ -2,7 +2,7 @@
 
 This folder contains a small utility to convert pulmonary function test (PFT) XML files into structured JSON and CSV formats.
 
-The logic was originally developed in `pft_xml.ipynb` and is now packaged as the command line script `pft_extraction.py`.
+The logic was originally developed in `pft_xml.ipynb` and is now packaged as the command line script `pft_extractor.py`.
 
 ## Getting Started
 
@@ -11,7 +11,7 @@ The logic was originally developed in `pft_xml.ipynb` and is now packaged as the
 3. Run the script:
 
 ```bash
-python pft_extraction.py
+python pft_extractor.py input/*.xml --output output
 ```
 
 Results for each XML file are saved in the `output/` folder as `{name}_extracted.json` and `{name}_extracted.csv`.


### PR DESCRIPTION
## Summary
- fix stray line at end of README
- update documentation to reference `pft_extractor.py`
- ensure both readmes use the same command line example

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_6870c5b9ddf083209b17e8321dc80d75